### PR TITLE
Add minimal front-end demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Demo de Panel Web
+
+Este repositorio contiene una demo de un panel minimalista en los colores gris, negro y blanco. Incluye tres secciones principales: Reportes, Operaciones y Administración. Las tarjetas de la sección de Reportes cargan información de ejemplo desde un API pública.
+
+Para probar la demo, abre `index.html` en un navegador web.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Demo de Panel</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Panel de Control</h1>
+        <nav>
+            <ul>
+                <li><a href="#reportes">Reportes</a></li>
+                <li><a href="#operaciones">Operaciones</a></li>
+                <li><a href="#admin">Administraci&oacute;n</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section id="reportes">
+            <h2>Reportes</h2>
+            <div class="cards">
+                <article class="card" id="empleados">
+                    <h3>Empleados</h3>
+                    <div class="data" data-endpoint="https://jsonplaceholder.typicode.com/users"></div>
+                </article>
+                <article class="card" id="vendings">
+                    <h3>Vendings</h3>
+                    <div class="data" data-endpoint="https://jsonplaceholder.typicode.com/posts"></div>
+                </article>
+                <article class="card" id="inventario">
+                    <h3>Inventario</h3>
+                    <div class="data" data-endpoint="https://jsonplaceholder.typicode.com/todos"></div>
+                </article>
+            </div>
+        </section>
+
+        <section id="operaciones">
+            <h2>Operaciones</h2>
+            <div class="cards">
+                <article class="card">
+                    <h3>Vendings</h3>
+                    <p>Opciones para gestionar las m&aacute;quinas vending.</p>
+                </article>
+                <article class="card">
+                    <h3>Inventario</h3>
+                    <p>Opciones para administrar el inventario.</p>
+                </article>
+            </div>
+        </section>
+
+        <section id="admin">
+            <h2>Administraci&oacute;n</h2>
+            <p>Secci&oacute;n de gesti&oacute;n administrativa.</p>
+        </section>
+    </main>
+
+    <footer>
+        <p>Demo minimalista</p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,20 @@
+// Función básica para cargar datos de ejemplo desde un API
+function cargarDatos() {
+    document.querySelectorAll('.data').forEach(div => {
+        const endpoint = div.getAttribute('data-endpoint');
+        if (endpoint) {
+            fetch(endpoint)
+                .then(resp => resp.json())
+                .then(data => {
+                    const pre = document.createElement('pre');
+                    pre.textContent = JSON.stringify(data.slice(0, 3), null, 2);
+                    div.appendChild(pre);
+                })
+                .catch(() => {
+                    div.textContent = 'Error al cargar los datos';
+                });
+        }
+    });
+}
+
+document.addEventListener('DOMContentLoaded', cargarDatos);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,49 @@
+body {
+    margin: 0;
+    font-family: Arial, Helvetica, sans-serif;
+    background-color: #ffffff;
+    color: #000000;
+}
+
+header {
+    background-color: #333333;
+    color: #ffffff;
+    padding: 1rem;
+    text-align: center;
+}
+
+nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+}
+
+nav a {
+    color: #ffffff;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.cards {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.card {
+    border: 1px solid #cccccc;
+    background-color: #f5f5f5;
+    padding: 1rem;
+    flex: 1 1 200px;
+}
+
+footer {
+    background-color: #333333;
+    color: #ffffff;
+    text-align: center;
+    padding: 0.5rem;
+    margin-top: 2rem;
+}


### PR DESCRIPTION
## Summary
- create a simple panel with sections for Reportes, Operaciones and Administración
- demo loads placeholder API data
- add clean gray/black/white styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684757e95e8c832b935cff26d3dcf2eb